### PR TITLE
Wording change for converter

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -662,7 +662,7 @@ Open Issues
 ``converter`` field descriptor parameter
 ----------------------------------------
 The attrs library supports a ``converter`` field descriptor parameter,
-which is passed a callable that is called by the generated
+which is a callable that is called by the generated
 ``__init__`` method to convert the supplied value to some other
 desired value. This is tricky to support since the parameter type in
 the synthesized __init__ method needs to accept uncovered values, but


### PR DESCRIPTION
From https://www.attrs.org/en/stable/api.html#attr.ib it looks like the converter is just passed the input value; the previous wording here sounded like the converter itself got passed a callable.